### PR TITLE
CCCAS-1105 Update AssessmentItem attribute to correspond to 2.0 specs…

### DIFF
--- a/qtiworks-jqtiplus/src/main/java/uk/ac/ed/ph/jqtiplus/node/item/AssessmentItem.java
+++ b/qtiworks-jqtiplus/src/main/java/uk/ac/ed/ph/jqtiplus/node/item/AssessmentItem.java
@@ -122,7 +122,7 @@ public class AssessmentItem extends AbstractNode implements AssessmentObject {
         getAttributes().add(new StringAttribute(this, ATTR_TITLE_NAME, true));
         getAttributes().add(new StringAttribute(this, ATTR_LABEL_NAME, false));
         getAttributes().add(new StringAttribute(this, ATTR_LANG_NAME, XMLConstants.XML_NS_URI, null, false));
-        getAttributes().add(new BooleanAttribute(this, ATTR_ADAPTIVE_NAME, true));
+        getAttributes().add(new BooleanAttribute(this, ATTR_ADAPTIVE_NAME, false, false));
         getAttributes().add(new BooleanAttribute(this, ATTR_TIME_DEPENDENT_NAME, true));
         getAttributes().add(new StringAttribute(this, ATTR_TOOL_NAME_NAME, false));
         getAttributes().add(new StringAttribute(this, ATTR_TOOL_VERSION_NAME, false));

--- a/qtiworks-jqtiplus/src/test/java/uk/ac/ed/ph/jqtiplus/serialization/QtiSerializerTest.java
+++ b/qtiworks-jqtiplus/src/test/java/uk/ac/ed/ph/jqtiplus/serialization/QtiSerializerTest.java
@@ -66,7 +66,7 @@ public class QtiSerializerTest {
         final String expectedXml = "<assessmentItem xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'"
                 + " xmlns='http://www.imsglobal.org/xsd/imsqti_v2p1'"
                 + " xsi:schemaLocation='http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/imsqti_v2p1.xsd'"
-                + " identifier='' title='' adaptive='' timeDependent=''/>";
+                + " identifier='' title='' timeDependent=''/>";
 
         serializeAndCompare(item, expectedXml, new SaxFiringOptions());
     }
@@ -79,7 +79,7 @@ public class QtiSerializerTest {
         saxFiringOptions.setOmitSchemaLocation(true);
 
         final String expectedXml = "<assessmentItem xmlns='http://www.imsglobal.org/xsd/imsqti_v2p1'"
-                + " identifier='' title='' adaptive='' timeDependent=''/>";
+                + " identifier='' title='' timeDependent=''/>";
 
         serializeAndCompare(item, expectedXml, saxFiringOptions);
     }
@@ -94,7 +94,7 @@ public class QtiSerializerTest {
         final String expectedXml = "<q:assessmentItem xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'"
                 + " xmlns:q='http://www.imsglobal.org/xsd/imsqti_v2p1'"
                 + " xsi:schemaLocation='http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/imsqti_v2p1.xsd'"
-                + " identifier='' title='' adaptive='' timeDependent=''/>";
+                + " identifier='' title='' timeDependent=''/>";
 
 
         serializeAndCompare(item, expectedXml, saxFiringOptions);
@@ -114,7 +114,7 @@ public class QtiSerializerTest {
         final String expectedXml = "<assessmentItem xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'"
                 + " xmlns='http://www.imsglobal.org/xsd/imsqti_v2p1'"
                 + " xsi:schemaLocation='http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/imsqti_v2p1.xsd'"
-                + " identifier='' title='' adaptive='' timeDependent=''>"
+                + " identifier='' title='' timeDependent=''>"
                 + "<itemBody>"
                 + "<p xml:base='urn:test'/>"
                 + "</itemBody>"
@@ -137,7 +137,7 @@ public class QtiSerializerTest {
         final String expectedXml = "<assessmentItem xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'"
                 + " xmlns='http://www.imsglobal.org/xsd/imsqti_v2p1'"
                 + " xsi:schemaLocation='http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/imsqti_v2p1.xsd'"
-                + " identifier='' title='' adaptive='' timeDependent=''>"
+                + " identifier='' title='' timeDependent=''>"
                 + "<itemBody>"
                 + "<math xmlns='http://www.w3.org/1998/Math/MathML'><mrow/></math>"
                 + "</itemBody>"
@@ -162,7 +162,7 @@ public class QtiSerializerTest {
                 + " xmlns='http://www.imsglobal.org/xsd/imsqti_v2p1'"
                 + " xmlns:m='http://www.w3.org/1998/Math/MathML'"
                 + " xsi:schemaLocation='http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/imsqti_v2p1.xsd'"
-                + " identifier='' title='' adaptive='' timeDependent=''>"
+                + " identifier='' title='' timeDependent=''>"
                 + "<itemBody>"
                 + "<m:math><m:mrow/></m:math>"
                 + "</itemBody>"
@@ -188,7 +188,7 @@ public class QtiSerializerTest {
                 + " xmlns:m='http://www.imsglobal.org/xsd/imsqti_v2p1'"
                 + " xmlns:m0='http://www.w3.org/1998/Math/MathML'"
                 + " xsi:schemaLocation='http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/imsqti_v2p1.xsd'"
-                + " identifier='' title='' adaptive='' timeDependent=''>"
+                + " identifier='' title='' timeDependent=''>"
                 + "<m:itemBody>"
                 + "<m0:math><m0:mrow/></m0:math>"
                 + "</m:itemBody>"
@@ -211,7 +211,7 @@ public class QtiSerializerTest {
         final String expectedXml = "<assessmentItem xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'"
                 + " xmlns='http://www.imsglobal.org/xsd/imsqti_v2p1'"
                 + " xsi:schemaLocation='http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/imsqti_v2p1.xsd'"
-                + " identifier='' title='' adaptive='' timeDependent=''>"
+                + " identifier='' title='' timeDependent=''>"
                 + "<itemBody>"
                 + "<math xmlns='http://www.w3.org/1998/Math/MathML'>"
                 + "<silly xmlns='urn:silly'/>"


### PR DESCRIPTION
Update AssessmentItem attribute to correspond to 2.0 spec as read by Unicon Team.
Schema confirms adaptive attribute is optional. Update unit tests.
